### PR TITLE
computegf get beta from grid

### DIFF
--- a/src/GF.jl
+++ b/src/GF.jl
@@ -32,8 +32,10 @@ export computegf
 """
 function computegf(ed::EDCore,
                    grid::TimeGrid,
-                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}},
-                   β)
+                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}})
+
+  β = length(get_branch(grid.contour, imaginary_branch))
+
   en = energies(ed)
   ρ = density_matrix(ed, β)
 
@@ -89,17 +91,17 @@ function computegf(ed::EDCore,
 end
 
 """
-  Compute Green's function on a given Keldysh contour at inverse temperature β
+  Compute Green's function on a given Keldysh contour
 
   This method returns one TimeGF object corresponding to one diagonal matrix
   element of Keldysh GF.
 """
-function computegf(ed::EDCore, grid::TimeGrid, c_cdag_index::IndicesType, β)
-  computegf(ed, grid, [(c_cdag_index, c_cdag_index)], β)[1]
+function computegf(ed::EDCore, grid::TimeGrid, c_cdag_index::IndicesType)
+  computegf(ed, grid, [(c_cdag_index, c_cdag_index)])[1]
 end
 
 """
-  Compute Green's function on a given Keldysh contour at inverse temperature β
+  Compute Green's function on a given Keldysh contour
 
   This method returns a matrix of TimeGF objects constructed from the direct
   product of `c_indices` and `cdag_indices`.
@@ -107,9 +109,8 @@ end
 function computegf(ed::EDCore,
                    grid::TimeGrid,
                    c_indices::Vector{IndicesType},
-                   cdag_indices::Vector{IndicesType},
-                   β)
+                   cdag_indices::Vector{IndicesType})
   c_cdag_index_pairs = [(i, j) for i in c_indices for j in cdag_indices]
-  reshape(computegf(ed, grid, c_cdag_index_pairs, β),
+  reshape(computegf(ed, grid, c_cdag_index_pairs),
           (length(c_indices), length(cdag_indices)))
 end

--- a/test/GF.jl
+++ b/test/GF.jl
@@ -76,11 +76,22 @@ d = IndicesType(["down", 0])
 u = IndicesType(["up", 0])
 
 @test computegf(ed, grid, [(d, d), (u, u)]) == gf
+@test computegf(ed, grid, [(d, d), (u, u)], β) == gf
 
 gf_matrix = computegf(ed, grid, [d,u], [d,u])
 @test gf_matrix[1,1] == gf[1]
 @test gf_matrix[1,2] == TimeGF((t1,t2) -> 0, grid)
 @test gf_matrix[2,1] == TimeGF((t1,t2) -> 0, grid)
 @test gf_matrix[2,2] == gf[2]
+
+gf_matrix = computegf(ed, grid, [d,u], [d,u], β)
+@test gf_matrix[1,1] == gf[1]
+@test gf_matrix[1,2] == TimeGF((t1,t2) -> 0, grid)
+@test gf_matrix[2,1] == TimeGF((t1,t2) -> 0, grid)
+@test gf_matrix[2,2] == gf[2]
+
+# Attempt to call computegf() on a 2-branch contour and without β
+grid2 = TimeGrid(Contour(keldysh_contour, tmax = tmax), npts_real = npts_real)
+@test_throws DomainError computegf(ed, grid2, [d,u], [d,u])
 
 end

--- a/test/GF.jl
+++ b/test/GF.jl
@@ -59,7 +59,7 @@ ed = EDCore(H, soi)
 contour = twist(Contour(full_contour, tmax = tmax, β=β))
 grid = TimeGrid(contour, npts_real = npts_real, npts_imag = npts_imag)
 
-gf = [computegf(ed, grid, IndicesType([s, 0]), β) for s in spins]
+gf = [computegf(ed, grid, IndicesType([s, 0])) for s in spins]
 
 test_dir = @__DIR__
 h5open(test_dir * "/GF.ref.h5", "r") do ref_file
@@ -75,9 +75,9 @@ end
 d = IndicesType(["down", 0])
 u = IndicesType(["up", 0])
 
-@test computegf(ed, grid, [(d, d), (u, u)], β) == gf
+@test computegf(ed, grid, [(d, d), (u, u)]) == gf
 
-gf_matrix = computegf(ed, grid, [d,u], [d,u], β)
+gf_matrix = computegf(ed, grid, [d,u], [d,u])
 @test gf_matrix[1,1] == gf[1]
 @test gf_matrix[1,2] == TimeGF((t1,t2) -> 0, grid)
 @test gf_matrix[2,1] == TimeGF((t1,t2) -> 0, grid)


### PR DESCRIPTION
Suggestion to drop the explicit beta parameter in the Green's function calculator. The inverse temperature is here obtained from the contour grid.