### PR TITLE
[GF] explicit import of theta function from Keldysh.jl

### DIFF
--- a/src/GF.jl
+++ b/src/GF.jl
@@ -18,6 +18,7 @@
 
 using KeldyshED: EDCore
 using Keldysh
+import Keldysh: θ
 using LinearAlgebra: Diagonal, tr
 using Distributed
 @everywhere using SharedArrays


### PR DESCRIPTION
Fix regression in `Keldysh.jl` no longer exporting the theta function. (Explicit imports FTW) ;)