### PR TITLE
Port GF.jl to Keldysh.jl 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ branches:
     - travis
 
 before_script:
-  - julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/kleinhenz/Keldysh.jl.git\", rev=\"v0.5.1\"))"
+  - julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/kleinhenz/Keldysh.jl.git\", rev=\"v0.6.0\"))"
   - julia -e "using Pkg; Pkg.add(\"HDF5\")"
   - julia -e "using Pkg; Pkg.add(\"ArgParse\")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ branches:
     - travis
 
 before_script:
-  - julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/kleinhenz/Keldysh.jl.git\", rev=\"v0.6.0\"))"
+  - julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/kleinhenz/Keldysh.jl.git\", rev=\"v0.6.1\"))"
   - julia -e "using Pkg; Pkg.add(\"HDF5\")"
   - julia -e "using Pkg; Pkg.add(\"ArgParse\")"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 .PHONY: test
 test:
+	JULIA_PROJECT="$(CURDIR)" julia test/runtests.jl
 	JULIA_PROJECT="$(CURDIR)" julia -p 4 test/runtests.jl

--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Keldysh = "0.5.1"
+Keldysh = "0.6.0"
 julia = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeldyshED"
 uuid = "675b6b9c-7c2f-11e9-3bf3-dfd4d61640f7"
 authors = ["Igor Krivenko <igor.s.krivenko@gmail.com>"]
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/Project.toml
+++ b/Project.toml
@@ -14,5 +14,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Keldysh = "0.6.0"
+Keldysh = "0.6.1"
 julia = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Keldysh = "50f2bc7e-5fd7-11e9-13c7-85fb88b4f34f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ KeldyshED.jl
 Equilibrium Exact Diagonalization solver for finite fermionic models that can
 also compute Green's functions on the Keldysh contour.
 
-Copyright (C) 2019 Igor Krivenko <igor.s.krivenko@gmail.com>  
+Copyright (C) 2019-2021 Igor Krivenko <igor.s.krivenko@gmail.com>
 Copyright (C) 2015 P. Seth, I. Krivenko, M. Ferrero and O. Parcollet
 
 This is my first attempt at writing Julia code and, to a large extent, a
@@ -24,7 +24,7 @@ typing the following commands in Julia's `Pkg` REPL:
 
     add HDF5
     add ArgParse
-    add https://github.com/kleinhenz/Keldysh.jl.git#v0.5.1
+    add https://github.com/kleinhenz/Keldysh.jl.git#v0.6.0
 
 Some usage examples can be found in the `test` subdirectory.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ typing the following commands in Julia's `Pkg` REPL:
 
     add HDF5
     add ArgParse
-    add https://github.com/kleinhenz/Keldysh.jl.git#v0.6.0
+    add https://github.com/kleinhenz/Keldysh.jl.git#v0.6.1
 
 Some usage examples can be found in the `test` subdirectory.
 

--- a/src/GF.jl
+++ b/src/GF.jl
@@ -168,7 +168,7 @@ end
 function computegf(ed::EDCore,
                    grid::FullTimeGrid,
                    c_index::IndicesType,
-                   cdag_index::IndicesType,
+                   cdag_index::IndicesType;
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    TimeInvariantFullTimeGF{ComplexF64, true}
   gf = TimeInvariantFullTimeGF(grid, 1, fermionic, true)
@@ -186,7 +186,7 @@ function computegf(ed::EDCore,
                    grid::KeldyshTimeGrid,
                    c_index::IndicesType,
                    cdag_index::IndicesType,
-                   β::Float64,
+                   β::Float64;
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    TimeInvariantKeldyshTimeGF{ComplexF64, true}
   gf = TimeInvariantKeldyshTimeGF(grid, 1, fermionic, true)
@@ -202,7 +202,7 @@ end
 function computegf(ed::EDCore,
                    grid::ImaginaryTimeGrid,
                    c_index::IndicesType,
-                   cdag_index::IndicesType,
+                   cdag_index::IndicesType;
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    ImaginaryTimeGF{ComplexF64, true}
   gf = ImaginaryTimeGF(grid, 1, fermionic, true)
@@ -222,7 +222,7 @@ end
 """
 function computegf(ed::EDCore,
                    grid::FullTimeGrid,
-                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}},
+                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}};
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    Vector{TimeInvariantFullTimeGF{ComplexF64, true}}
   map(c_cdag_index_pairs) do (c_index, cdag_index)
@@ -242,7 +242,7 @@ end
 function computegf(ed::EDCore,
                    grid::KeldyshTimeGrid,
                    c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}},
-                   β::Float64,
+                   β::Float64;
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    Vector{TimeInvariantKeldyshTimeGF{ComplexF64, true}}
   map(c_cdag_index_pairs) do (c_index, cdag_index)
@@ -260,7 +260,7 @@ end
 """
 function computegf(ed::EDCore,
                    grid::ImaginaryTimeGrid,
-                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}},
+                   c_cdag_index_pairs::Vector{Tuple{IndicesType, IndicesType}};
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    Vector{ImaginaryTimeGF{ComplexF64, true}}
   map(c_cdag_index_pairs) do (c_index, cdag_index)
@@ -283,7 +283,7 @@ end
 function computegf(ed::EDCore,
                    grid::FullTimeGrid,
                    c_indices::Vector{IndicesType},
-                   cdag_indices::Vector{IndicesType},
+                   cdag_indices::Vector{IndicesType};
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    TimeInvariantFullTimeGF{ComplexF64, false}
   norb = length(c_indices)
@@ -304,7 +304,7 @@ function computegf(ed::EDCore,
                    grid::KeldyshTimeGrid,
                    c_indices::Vector{IndicesType},
                    cdag_indices::Vector{IndicesType},
-                   β::Float64,
+                   β::Float64;
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    TimeInvariantKeldyshTimeGF{ComplexF64, false}
   norb = length(c_indices)
@@ -323,7 +323,7 @@ end
 function computegf(ed::EDCore,
                    grid::ImaginaryTimeGrid,
                    c_indices::Vector{IndicesType},
-                   cdag_indices::Vector{IndicesType},
+                   cdag_indices::Vector{IndicesType};
                    gf_filler::AbstractGFFiller = SerialGFFiller())::
                    ImaginaryTimeGF{ComplexF64, false}
   norb = length(c_indices)

--- a/src/GF.jl
+++ b/src/GF.jl
@@ -34,12 +34,12 @@ function computegf(ed::EDCore,
                    cdag_index::IndicesType,
                    β::Float64)::ComplexF64
   computegf(ed,
-            energies(ed),
-            density_matrix(ed, β),
             t1,
             t2,
             c_index,
-            cdag_index
+            cdag_index,
+            en = energies(ed),
+            ρ = density_matrix(ed, β)
   )
 end
 
@@ -51,12 +51,12 @@ end
   been computed.
 """
 function computegf(ed::EDCore,
-                   en,
-                   ρ,
                    t1::BranchPoint,
                    t2::BranchPoint,
                    c_index::IndicesType,
-                   cdag_index::IndicesType)::ComplexF64
+                   cdag_index::IndicesType;
+                   en,
+                   ρ)::ComplexF64
 
   greater = heaviside(t1, t2)
   Δt = greater ? (t1.val - t2.val) : (t2.val - t1.val)
@@ -152,7 +152,7 @@ function _computegf!(ed::EDCore,
   )
 
   gf_filler(gf, element_list) do t1, t2, c_index, cdag_index
-    computegf(ed, en, ρ, t1, t2, c_index, cdag_index)
+    computegf(ed, t1, t2, c_index, cdag_index, en = en, ρ = ρ)
   end
 end
 

--- a/test/GF.jl
+++ b/test/GF.jl
@@ -89,10 +89,10 @@ h5open(test_dir * "/GF.ref.h5", "r") do ref_file
                        (t1, t2) -> g_ref[t1, t2],
                        g_full_s[s].grid)
     @test gf_is_approx((t1, t2) -> g_keld_s[s][t1, t2],
-                       (t1, t2) -> g_ref(t1.val, t2.val),
+                       (t1, t2) -> g_ref(t1.bpoint, t2.bpoint),
                        g_keld_s[s].grid)
     @test gf_is_approx((t1, t2) -> g_imag_s[s][t1, t2],
-                       (t1, t2) -> g_ref(t1.val, t2.val),
+                       (t1, t2) -> g_ref(t1.bpoint, t2.bpoint),
                        g_imag_s[s].grid)
   end
 end

--- a/test/GF.jl
+++ b/test/GF.jl
@@ -75,12 +75,12 @@ gf_filler = nprocs() > 1 ? DistributedGFFiller() : SerialGFFiller()
 # Scalar GF
 #
 
-g_full_s = [computegf(ed, grid_full, d, d, gf_filler),
-            computegf(ed, grid_full, u, u, gf_filler)]
-g_keld_s = [computegf(ed, grid_keld, d, d, β, gf_filler),
-            computegf(ed, grid_keld, u, u, β, gf_filler)]
-g_imag_s = [computegf(ed, grid_imag, d, d, gf_filler),
-            computegf(ed, grid_imag, u, u, gf_filler)]
+g_full_s = [computegf(ed, grid_full, d, d, gf_filler = gf_filler),
+            computegf(ed, grid_full, u, u, gf_filler = gf_filler)]
+g_keld_s = [computegf(ed, grid_keld, d, d, β, gf_filler = gf_filler),
+            computegf(ed, grid_keld, u, u, β, gf_filler = gf_filler)]
+g_imag_s = [computegf(ed, grid_imag, d, d, gf_filler = gf_filler),
+            computegf(ed, grid_imag, u, u, gf_filler = gf_filler)]
 
 test_dir = @__DIR__
 h5open(test_dir * "/GF.ref.h5", "r") do ref_file
@@ -116,15 +116,15 @@ function test_gf_matrix_isapprox(G_matrix, G_scalar)
 end
 
 test_gf_matrix_isapprox(
-  computegf(ed, grid_full, [d, u], [d, u], gf_filler),
+  computegf(ed, grid_full, [d, u], [d, u], gf_filler = gf_filler),
   g_full_s
 )
 test_gf_matrix_isapprox(
-  computegf(ed, grid_keld, [d, u], [d, u], β, gf_filler),
+  computegf(ed, grid_keld, [d, u], [d, u], β, gf_filler = gf_filler),
   g_keld_s
 )
 test_gf_matrix_isapprox(
-  computegf(ed, grid_imag, [d, u], [d, u], gf_filler),
+  computegf(ed, grid_imag, [d, u], [d, u], gf_filler = gf_filler),
   g_imag_s
 )
 
@@ -144,15 +144,15 @@ function test_gf_list_isapprox(G1, G2)
 end
 
 test_gf_list_isapprox(
-  computegf(ed, grid_full, [(d, d), (u, u)], gf_filler),
+  computegf(ed, grid_full, [(d, d), (u, u)], gf_filler = gf_filler),
   g_full_s
 )
 test_gf_list_isapprox(
-  computegf(ed, grid_keld, [(d, d), (u, u)], β, gf_filler),
+  computegf(ed, grid_keld, [(d, d), (u, u)], β, gf_filler = gf_filler),
   g_keld_s
 )
 test_gf_list_isapprox(
-  computegf(ed, grid_imag, [(d, d), (u, u)], gf_filler),
+  computegf(ed, grid_imag, [(d, d), (u, u)], gf_filler = gf_filler),
   g_imag_s
 )
 


### PR DESCRIPTION
This PR is still work-in-progress and contains a few issues to be resolved.

- [ ] There are now 9 methods of `computegf()` instead of 3. The extra factor 3 comes from the time grid types (`FullTimeGrid`, `KeldyshTimeGrid` and `ImaginaryTimeGrid`). Is there a way to treat them all simultaneously (bodies of the methods are nearly identical) without compromising type stability?
- [x] Parallelization of `computegf()` does not work yet. Before I was using a `SharedArray`, which was concurrently filled by a `@distributed for` loop. At the end of the calculation I simply copied contents of the array into a new `TimeGF` object. Now that Keldysh.jl has a variety of storage schemes, it should provide some tools to implement parallelism/scatter-gather functionality, I believe.
- [x] Is there a way to set a single matrix element of a (t1, t2) slice of a matrix-valued GF? Right now I have to write
```
val_mat = zeros(T, norb, norb)
val_mat[c_n, cdag_n] = (greater ? -1im : 1im) * val
gf[t1, t2] += val_mat
```
- [x] Unit test: What is the best way to compare an `ImaginaryTimeGF`/`TimeInvariantKeldyshTimeGF` object with the respective portion of another `TimeInvariantFullTimeGF` object?