### PR TITLE
Fix complex EDCore creating real internal operators.

### DIFF
--- a/src/ed_core.jl
+++ b/src/ed_core.jl
@@ -233,8 +233,8 @@ function EDCore(hamiltonian::OperatorExpr{S},
   cdag_matrices = [Dict{Int,Matrix{S}}() for n=1:length(soi)]
   c_matrices = [Dict{Int,Matrix{S}}() for n=1:length(soi)]
   for (indices, n) in soi
-    cdag_matrices[n] = make_c_matrix(creation_connection[n], c_dag(indices...))
-    c_matrices[n] = make_c_matrix(annihilation_connection[n], c(indices...))
+    cdag_matrices[n] = make_c_matrix(creation_connection[n], c_dag(indices...; scalar_type = S))
+    c_matrices[n] = make_c_matrix(annihilation_connection[n], c(indices...; scalar_type = S))
   end
 
   EDCore{S}(full_hs,

--- a/src/ed_core.jl
+++ b/src/ed_core.jl
@@ -133,8 +133,8 @@ function EDCore(hamiltonian::OperatorExpr{S},
   Cd_elements = Vector{SparseMatrixCSC{S, Int}}(undef, length(soi))
   C_elements = Vector{SparseMatrixCSC{S, Int}}(undef, length(soi))
   for (indices, n) in soi
-    op_c_dag = Operator{FullHilbertSpace, S}(c_dag(indices...), soi)
-    op_c = Operator{FullHilbertSpace, S}(c(indices...), soi)
+    op_c_dag = Operator{FullHilbertSpace, S}(c_dag(indices...; scalar_type = S), soi)
+    op_c = Operator{FullHilbertSpace, S}(c(indices...; scalar_type = S), soi)
 
     Cd_elements[n], C_elements[n] = merge_subspaces!(SP, op_c_dag, op_c, true)
   end


### PR DESCRIPTION
I had some errors when using complex Hamiltonians. They seem to arise from some internal operators within EDCore that are initialized as real operators even when the Hamiltonian is complex. This fix simply ensures that these internal operator expressions are always created to be the same scalar type as the EDCore object.